### PR TITLE
Align API with the Iterator Helpers Proposal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@eslint/js": "^9.9.1",
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.16.3",
+        "@types/node": "^22.5.3",
         "del-cli": "^5.1.0",
         "eslint": "^9.9.1",
         "jest": "^29.7.0",
@@ -1677,9 +1677,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.3.tgz",
-      "integrity": "sha512-/wdGiWRkMOm53gAsSyFMXFZHbVg7C6CbkrzHNpaHoYfsUWPg7m6ZRKtvQjgvQ9i8WT540a3ydRlRQbxjY30XxQ==",
+      "version": "22.5.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.3.tgz",
+      "integrity": "sha512-njripolh85IA9SQGTAqbmnNZTdxv7X/4OYGPz8tgy5JDr8MP+uDBa921GpYEoDDnwm0Hmn5ZPeJgiiSTPoOzkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8837,9 +8837,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.3.tgz",
-      "integrity": "sha512-/wdGiWRkMOm53gAsSyFMXFZHbVg7C6CbkrzHNpaHoYfsUWPg7m6ZRKtvQjgvQ9i8WT540a3ydRlRQbxjY30XxQ==",
+      "version": "22.5.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.3.tgz",
+      "integrity": "sha512-njripolh85IA9SQGTAqbmnNZTdxv7X/4OYGPz8tgy5JDr8MP+uDBa921GpYEoDDnwm0Hmn5ZPeJgiiSTPoOzkQ==",
       "dev": true,
       "requires": {
         "undici-types": "~6.19.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@eslint/js": "^9.9.1",
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.16.3",
+    "@types/node": "^22.5.3",
     "del-cli": "^5.1.0",
     "eslint": "^9.9.1",
     "jest": "^29.7.0",

--- a/src/behavior.test.ts
+++ b/src/behavior.test.ts
@@ -70,6 +70,19 @@ test("awaiting a non-promise is a suspending operation", async () => {
   expect(log.output).toEqual(["simple", "called", "awaited", 42, 84]);
 });
 
+test("for-await works on a generator", async () => {
+  function* gen() {
+    yield* [1, 2, 3];
+  }
+
+  let result = 0;
+  for await (const n of gen()) {
+    result += n;
+  }
+
+  expect(result).toBe(6);
+});
+
 test("async generator without return statement has expected order of operations", () => {
   const log = logger();
   function* x(): Generator<number> {

--- a/src/generator.test22.ts
+++ b/src/generator.test22.ts
@@ -38,6 +38,18 @@ test("reduce of empty iterator throws TypeError", () => {
   expect(s).toThrow(TypeError);
 });
 
+test("reduce of empty iterator with undefined initial element returns undefined", () => {
+  function* gen() {
+    // Empty iterator
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const a = gen() as any;
+
+  const s = a.reduce((a, b) => a + b, undefined);
+
+  expect(s).toBeUndefined();
+});
+
 test("reduce of single-element iterator returns single element", () => {
   function* gen() {
     yield 42;

--- a/src/generator.test22.ts
+++ b/src/generator.test22.ts
@@ -3,15 +3,16 @@
 //   npm test -- --testRegex test22
 //
 
-test("generator mapping", () => {
+test("map works as expected", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const a: any = [1, 2, 3].values() as any;
-  console.log("YAY");
-  const s = Array.from(a.map((it) => it * it)).join();
-  expect(s).toEqual("1,4,9");
+
+  const s = Array.from(a.map((it) => it * it));
+
+  expect(s).toEqual([1, 4, 9]);
 });
 
-test("generator for mapping", () => {
+test("filter and map work as expected", () => {
   function* gen() {
     yield 1;
     yield 2;
@@ -19,7 +20,32 @@ test("generator for mapping", () => {
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const a = gen() as any;
-  console.log("YAY");
-  const s = Array.from(a.filter((x) => x > 1).map((it) => it * it)).join();
-  expect(s).toEqual("4,9");
+
+  const s = Array.from(a.filter((x) => x > 1).map((it) => it * it));
+
+  expect(s).toEqual([4, 9]);
+});
+
+test("reduce of empty iterator throws TypeError", () => {
+  function* gen() {
+    // Empty iterator
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const a = gen() as any;
+
+  const s = () => a.reduce((a, b) => a + b);
+
+  expect(s).toThrow(TypeError);
+});
+
+test("reduce of single-element iterator returns single element", () => {
+  function* gen() {
+    yield 42;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const a = gen() as any;
+
+  const s = a.reduce((a, b) => a + b);
+
+  expect(s).toBe(42);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,132 @@
-export interface AsyncStream<T> extends AsyncIterable<T> {
+/**
+ * An asynchronous stream that produces elements of type `T` on demand.
+ *
+ * This is an extension of the built-in `AsyncIterable<T>` protocol.
+ *
+ * The operations defined here in AsyncStream are a superset of the operations
+ * described in the [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers)
+ * proposal.
+ *
+ * The behavior of all operations here that correspond to operations in the
+ * `Async Iterator Helpers` proposal are defined (as best as possible) to match
+ * exactly with the behavior of the corresponding `Async Iterator Helpers`
+ * operations. This is intended to allow users of this library to seamlessly
+ * switch between this library and the `Async Iterator Helpers` once those are
+ * implemented and available.
+ *
+ * However, this library is NOT a polyfill for `Async Iterator Helpers`. To use
+ * this library, an async iterable iterator or generator needs to be explicitly
+ * wrapped in an AsyncStream like in this example:
+ *
+ * ```
+ * import "streams/asyncGenerator";
+ *
+ * async function* generator() {
+ *   yield* [1, 2, 3];
+ * }
+ *
+ * generator()               // returns an AsyncGenerator
+ *   .stream()               // convert to AsyncStream first!
+ *   .forEach(console.log);  // use the AsyncStream APIs
+ * ```
+ */
+export interface AsyncStream<T> extends AsyncIterableIterator<T> {
+  //
   // Intermediate operations
+  //
+
+  /**
+   * Returns a new stream that skips elements of this stream not matched by the
+   * `predicate`.
+   *
+   * See also [IteratorHelpers#filter](https://github.com/tc39/proposal-iterator-helpers#filterfiltererfn).
+   *
+   * @param predicate a function that decides whether to include each element
+   * in the new stream (true) or to exclude the element (false)
+   */
   filter(predicate: (_: T) => boolean): AsyncStream<T>;
+
+  /**
+   * Returns a new stream that transforms each element of this stream
+   * using the provided function.
+   *
+   * See also [IteratorHelpers#map](https://github.com/tc39/proposal-iterator-helpers#mapmapperfn).
+   *
+   * @alias
+   * @param transform a function to apply to each element of this stream
+   */
   map<U>(transform: (_: T) => U): AsyncStream<U>;
+
+  /**
+   * Like `map` but the `transform` is an async function that returns a Promise
+   * and is awaited before producing the next transformed element.
+   *
+   * @param transform an async function to apply to each element of this stream
+   */
   mapAwait<U>(transform: (_: T) => Promise<U>): AsyncStream<U>;
+
+  /**
+   *
+   * See also [IteratorHelpers#flatMap](https://github.com/tc39/proposal-iterator-helpers#flatmapmapperfn).
+   *
+   * @param transform
+   */
   flatMap<U>(transform: (_: T) => AsyncStream<U>): AsyncStream<U>;
+
   flatMapAwait<U>(transform: (_: T) => Promise<AsyncStream<U>>): AsyncStream<U>;
+
   batch(batchSize: number): AsyncStream<T[]>;
+
+  /**
+   * Returns a new stream that produces up to the first `limit` number of
+   * elements of this stream.
+   *
+   * See also [IteratorHelpers#take](https://github.com/tc39/proposal-iterator-helpers#takelimit).
+   *
+   * @param limit the maximum number of items to produce
+   */
+  take(limit: number): AsyncStream<T>;
+
+  /**
+   * An alias for `take`.
+   *
+   * @alias take
+   * @param maxSize the maximum number of items to produce
+   */
   limit(maxSize: number): AsyncStream<T>;
+
+  /**
+   *
+   * See also [IteratorHelpers#drop](https://github.com/tc39/proposal-iterator-helpers#droplimit).
+   *
+   * @param n
+   */
+  drop(n: number): AsyncStream<T>;
+
+  /**
+   * An alias for `drop`.
+   *
+   * @alias drop
+   * @param n the number of elements to skip from the start of this stream
+   */
   skip(n: number): AsyncStream<T>;
+
   dropWhile(predicate: (_: T) => boolean): AsyncStream<T>;
+
   takeWhile(predicate: (_: T) => boolean): AsyncStream<T>;
+
   peek(observer: (_: T) => void): AsyncStream<T>;
 
+  //
   // Terminal operations
+  //
+
+  /**
+   *
+   * See also [IteratorHelpers#forEach](https://github.com/tc39/proposal-iterator-helpers#foreachfn).
+   *
+   * @param block
+   */
   forEach(block: (_: T) => unknown | Promise<unknown>): Promise<void>;
   collect<A, R>(
     container: A,
@@ -20,23 +134,110 @@ export interface AsyncStream<T> extends AsyncIterable<T> {
     finisher: (_: A) => R,
   ): Promise<R>;
   reduceLeft<R>(initial: R, accumulator: (r: R, t: T) => R): Promise<R>;
-  reduce(accumulator: (a: T, b: T) => T): Promise<T | null>;
+
+  /**
+   *
+   * See also [IteratorHelpers#reduce](https://github.com/tc39/proposal-iterator-helpers#reducereducer--initialvalue-).
+   *
+   * @param accumulator
+   * @param initial
+   */
+  reduce(accumulator: (a: T, b: T) => T, initial?: T): Promise<T>;
+
+  /**
+   * Like {@link AsyncStream#reduce()} but returns `undefined` if this stream is
+   * empty instead of throwing `TypeError`.
+   *
+   * @param accumulator
+   * @param initial
+   */
+  fold(accumulator: (a: T, b: T) => T, initial?: T): Promise<T | undefined>;
+
+  /**
+   *
+   * See also [IteratorHelpers#every](https://github.com/tc39/proposal-iterator-helpers#everyfn).
+   *
+   * @param predicate
+   */
+  every(predicate: (_: T) => boolean): Promise<boolean>;
+
+  /**
+   * An alias for `every`.
+   *
+   * @param predicate
+   */
   all(predicate: (_: T) => boolean): Promise<boolean>;
+
+  /**
+   * See also [IteratorHelpers#some](https://github.com/tc39/proposal-iterator-helpers#somefn).
+   *
+   * @param predicate
+   */
+  some(predicate: (_: T) => boolean): Promise<boolean>;
+
+  /**
+   * An alias for `some`.
+   *
+   * @param predicate
+   */
   any(predicate: (_: T) => boolean): Promise<boolean>;
   none(predicate: (_: T) => boolean): Promise<boolean>;
   count(): Promise<number>;
-  first(predicate: (_: T) => boolean): Promise<T | null>;
-  last(predicate: (_: T) => boolean): Promise<T | null>;
-  max(comparator: (a: T, b: T) => number): Promise<T | null>;
-  min(comparator: (a: T, b: T) => number): Promise<T | null>;
+
+  /**
+   * An alias for `first`.
+   *
+   * See also [IteratorHelpers#find](https://github.com/tc39/proposal-iterator-helpers#findfn).
+   *
+   * @param predicate
+   */
+  find(predicate: (_: T) => boolean): Promise<T | undefined>;
+
+  first(predicate: (_: T) => boolean): Promise<T | undefined>;
+  last(predicate: (_: T) => boolean): Promise<T | undefined>;
+  max(comparator: (a: T, b: T) => number): Promise<T | undefined>;
+  min(comparator: (a: T, b: T) => number): Promise<T | undefined>;
+
+  /**
+   * See also [IteratorHelpers#toArray](https://github.com/tc39/proposal-iterator-helpers#toarray).
+   */
   toArray(): Promise<T[]>;
 }
 
-class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
+class AsyncStreamOfIterator<T>
+  implements AsyncStream<T>, AsyncIterableIterator<T>
+{
   constructor(private readonly iterator: AsyncIterator<T>) {}
 
+  // The AsyncIterator protocol
+  next(...args: [] | [undefined]) {
+    return this.iterator.next(...args);
+  }
+
+  readonly return = this.iterator.return
+    ? (value?: unknown) => {
+        return this.iterator.return!(value);
+      }
+    : undefined;
+
+  readonly throw = this.iterator.throw
+    ? (e?: unknown) => {
+        return this.iterator.throw!(e);
+      }
+    : undefined;
+
+  // Aliases
+  readonly limit = this.take;
+  readonly skip = this.drop;
+  readonly find = this.first;
+  readonly all = this.every;
+  readonly any = this.some;
+
+  /**
+   * @returns the AsyncIterator wrapped by this AsyncStream
+   */
   [Symbol.asyncIterator]() {
-    return this.iterator;
+    return this;
   }
 
   filter(predicate: (_: T) => boolean): AsyncStream<T> {
@@ -109,7 +310,7 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return new AsyncStreamOfIterator(batched(this));
   }
 
-  limit(maxSize: number): AsyncStream<T> {
+  take(maxSize: number): AsyncStream<T> {
     async function* limited(it: AsyncStream<T>) {
       let count = 0;
       if (count >= maxSize) {
@@ -126,7 +327,7 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return new AsyncStreamOfIterator(limited(this));
   }
 
-  skip(n: number): AsyncStream<T> {
+  drop(n: number): AsyncStream<T> {
     async function* skipped(it: AsyncStream<T>) {
       let count = 0;
       for await (const v of it) {
@@ -199,7 +400,7 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return result;
   }
 
-  async all(predicate: (_: T) => boolean): Promise<boolean> {
+  async every(predicate: (_: T) => boolean): Promise<boolean> {
     for await (const v of this) {
       if (!(await predicate(v))) {
         return false;
@@ -208,7 +409,7 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return true;
   }
 
-  async any(predicate: (_: T) => boolean): Promise<boolean> {
+  async some(predicate: (_: T) => boolean): Promise<boolean> {
     for await (const v of this) {
       if (await predicate(v)) {
         return true;
@@ -234,17 +435,17 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return count;
   }
 
-  async first(predicate: (_: T) => boolean): Promise<T | null> {
+  async first(predicate: (_: T) => boolean): Promise<T | undefined> {
     for await (const v of this) {
       if (await predicate(v)) {
         return v;
       }
     }
-    return null;
+    return undefined;
   }
 
-  async last(predicate: (_: T) => boolean): Promise<T | null> {
-    let result: T | null = null;
+  async last(predicate: (_: T) => boolean): Promise<T | undefined> {
+    let result: T | undefined;
     for await (const v of this) {
       if (await predicate(v)) {
         result = v;
@@ -253,37 +454,62 @@ class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
     return result;
   }
 
-  async max(comparator: (a: T, b: T) => number): Promise<T | null> {
-    let result: T | null = null;
+  async max(comparator: (a: T, b: T) => number): Promise<T | undefined> {
+    let result: T | undefined;
+    let firstItem = true;
     for await (const v of this) {
-      if (result === null) {
+      if (firstItem) {
         result = v;
+        firstItem = false;
       } else {
-        result = comparator(result, v) > 0 ? result : v;
+        result = comparator(result!, v) > 0 ? result : v;
       }
     }
     return result;
   }
 
-  async min(comparator: (a: T, b: T) => number): Promise<T | null> {
-    let result: T | null = null;
+  async min(comparator: (a: T, b: T) => number): Promise<T | undefined> {
+    let result: T | undefined;
+    let firstItem = true;
     for await (const v of this) {
-      if (result === null) {
+      if (firstItem) {
         result = v;
+        firstItem = false;
       } else {
-        result = comparator(result, v) < 0 ? result : v;
+        result = comparator(result!, v) < 0 ? result : v;
       }
     }
     return result;
   }
 
-  async reduce(adder: (a: T, b: T) => T): Promise<T | null> {
-    let result: T | null = null;
+  async reduce(adder: (a: T, b: T) => T, initial?: T): Promise<T> {
+    const hasInitial = arguments.length >= 2;
+    let firstItem = !hasInitial;
+    let result = initial;
     for await (const v of this) {
-      if (result === null) {
+      if (firstItem) {
         result = v;
+        firstItem = false;
       } else {
-        result = adder(result, v);
+        result = adder(result!, v);
+      }
+    }
+    if (firstItem) {
+      throw new TypeError("reduce without initial value but stream is empty");
+    }
+    return result!;
+  }
+
+  async fold(adder: (a: T, b: T) => T, initial?: T): Promise<T | undefined> {
+    const hasInitial = arguments.length >= 2;
+    let firstItem = !hasInitial;
+    let result = initial;
+    for await (const v of this) {
+      if (firstItem) {
+        result = v;
+        firstItem = false;
+      } else {
+        result = adder(result!, v);
       }
     }
     return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export interface AsyncStream<T> extends AsyncIterable<T> {
   toArray(): Promise<T[]>;
 }
 
-class AsyncStreamOfIterator<T> implements AsyncStream<T> {
+class AsyncStreamOfIterator<T> implements AsyncStream<T>, AsyncIterable<T> {
   constructor(private readonly iterator: AsyncIterator<T>) {}
 
   [Symbol.asyncIterator]() {
@@ -316,7 +316,7 @@ export function streamAsyncIterable<T>(
 }
 
 export function asyncStream<T>(
-  it: Iterable<T> | AsyncIterable<T> | AsyncIterator<T>,
+  it: Iterable<T> | Iterator<T> | AsyncIterable<T> | AsyncIterator<T>,
 ): AsyncStream<T> {
   if (typeof it[Symbol.iterator] === "function") {
     return asyncStreamIterable(it as Iterable<T>);

--- a/src/polyfill/asyncGenerator.test.ts
+++ b/src/polyfill/asyncGenerator.test.ts
@@ -1,0 +1,14 @@
+import "./asyncGenerator";
+
+test("AsyncGenerator.stream polyfill works", async () => {
+  async function* gen() {
+    yield* [1, 2, 3];
+  }
+
+  const r = await gen()
+    .stream()
+    .map((x) => x * 2)
+    .toArray();
+
+  expect(r).toEqual([2, 4, 6]);
+});

--- a/src/polyfill/asyncGenerator.ts
+++ b/src/polyfill/asyncGenerator.ts
@@ -1,0 +1,15 @@
+import { AsyncStream, streamAsyncIterable } from "../index";
+
+declare global {
+  interface AsyncGenerator<T> {
+    stream(): AsyncStream<T>;
+  }
+}
+
+const AsyncGeneratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf((async function* () {})()),
+);
+
+AsyncGeneratorPrototype.stream = function () {
+  return streamAsyncIterable(this);
+};

--- a/src/polyfill/generator.test.ts
+++ b/src/polyfill/generator.test.ts
@@ -1,0 +1,64 @@
+import "./generator";
+
+test("Generator.stream polyfill works with generator functions", async () => {
+  function* gen() {
+    yield* [1, 2, 3];
+  }
+
+  const r = await gen()
+    .asyncStream()
+    .map((x) => x * 2)
+    .toArray();
+
+  expect(r).toEqual([2, 4, 6]);
+});
+
+test("Generator.stream polyfill works with Array.values()", async () => {
+  const gen = [1, 2, 3].values();
+
+  const r = await gen
+    .asyncStream()
+    .map((x) => x * 2)
+    .toArray();
+
+  expect(r).toEqual([2, 4, 6]);
+});
+
+test("Generator.stream polyfill works with Map.keys()", async () => {
+  const map = new Map<number, string>();
+  map.set(1, "a");
+  map.set(2, "b");
+  map.set(3, "c");
+  const gen = map.keys();
+
+  const r = await gen
+    .asyncStream()
+    .map((x) => x * 2)
+    .toArray();
+
+  expect(r).toEqual([2, 4, 6]);
+});
+
+test("Generator.stream polyfill works with Map.values()", async () => {
+  const map = new Map<number, string>();
+  map.set(1, "a");
+  map.set(2, "b");
+  map.set(3, "c");
+  const gen = map.values();
+
+  const r = await gen
+    .asyncStream()
+    .map((x) => x.toUpperCase())
+    .toArray();
+
+  expect(r).toEqual(["A", "B", "C"]);
+});
+
+test("the Array prototype is untouched by the polyfill", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const arr = [1, 2, 3] as any;
+
+  const f = () => arr.stream();
+
+  expect(f).toThrow(TypeError);
+});

--- a/src/polyfill/generator.ts
+++ b/src/polyfill/generator.ts
@@ -1,0 +1,27 @@
+import { AsyncStream, asyncStreamIterable } from "../index";
+
+declare global {
+  interface Generator<T> {
+    asyncStream(): AsyncStream<T>;
+  }
+
+  interface IterableIterator<T> {
+    asyncStream(): AsyncStream<T>;
+  }
+}
+
+const GeneratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf((function* () {})()),
+);
+
+const IterableIteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([].values()),
+);
+
+GeneratorPrototype.asyncStream = function () {
+  return asyncStreamIterable(this);
+};
+
+IterableIteratorPrototype.asyncStream = function () {
+  return asyncStreamIterable(this);
+};


### PR DESCRIPTION
*Background*

See https://github.com/tc39/proposal-async-iterator-helpers and https://github.com/tc39/proposal-iterator-helpers

*Changes*

There are some breaking API changes:

* `reduce` throws instead of returning null
* other methods such as `find`, `first` etc return `undefined` instead of `null`
